### PR TITLE
Update GNOME runtime to 41

### DIFF
--- a/com.belmoussaoui.Authenticator.json
+++ b/com.belmoussaoui.Authenticator.json
@@ -89,9 +89,8 @@
             "sources" : [
                 {
                     "type" : "git",
-                    "branch" : "1.18",
-                    "url" : "https://gitlab.freedesktop.org/gstreamer/gstreamer.git",
-                    "commit": "102232fa62ccec0f86ce6ff5bd65fbb3ac83a77c"
+                    "tag" : "1.18",
+                    "url" : "https://gitlab.freedesktop.org/gstreamer/gstreamer.git"
                 }
             ]
         },
@@ -108,9 +107,8 @@
             "sources" : [
                 {
                     "type" : "git",
-                    "branch" : "1.18",
-                    "url" : "https://gitlab.freedesktop.org/gstreamer/gst-plugins-base.git",
-                    "commit": "64fa797ce57237ec4f527e1746a2067cfa05937d"
+                    "tag" : "1.18",
+                    "url" : "https://gitlab.freedesktop.org/gstreamer/gst-plugins-base.git"
                 }
             ]
         },
@@ -128,9 +126,8 @@
             "sources" : [
                 {
                     "type" : "git",
-                    "branch" : "1.18",
-                    "url" : "https://gitlab.freedesktop.org/gstreamer/gst-plugins-good.git",
-                    "commit": "b80518152799385fc31ac8fce086541ff1b97812"
+                    "tag" : "1.18",
+                    "url" : "https://gitlab.freedesktop.org/gstreamer/gst-plugins-good.git"
                 },
                 {
                     "type" : "patch",
@@ -153,8 +150,7 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad.git",
-                    "branch" : "1.18",
-                    "commit": "c0c804384ca29fecd8329de0745693ed11784b81"
+                    "tag" : "1.18"
                 }
             ]
         },

--- a/com.belmoussaoui.Authenticator.json
+++ b/com.belmoussaoui.Authenticator.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.belmoussaoui.Authenticator",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "40",
+    "runtime-version": "41",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable"],
     "command": "authenticator",

--- a/com.belmoussaoui.Authenticator.json
+++ b/com.belmoussaoui.Authenticator.json
@@ -41,7 +41,6 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/exalm/libadwaita.git",
-                    "branch": "main",
                     "commit": "8f434971a180108790a93cecef853d66a61cbfe1"
                 }
             ]

--- a/com.belmoussaoui.Authenticator.json
+++ b/com.belmoussaoui.Authenticator.json
@@ -64,7 +64,7 @@
             "sources": [{
                     "type": "git",
                     "url": "git://git.linuxtv.org/zbar.git",
-                    "tag": "0.23"
+                    "tag": "0.23.1"
                 },
                 {
                     "type": "script",
@@ -72,6 +72,10 @@
                     "commands": [
                         "autoreconf -vfi -W none"
                     ]
+                },
+                {
+                    "type": "patch",
+                    "path": "zbar-autoconf-2.70.patch"
                 }
             ]
         },

--- a/zbar-autoconf-2.70.patch
+++ b/zbar-autoconf-2.70.patch
@@ -1,0 +1,35 @@
+From 89e7900d85dd54ef351a7ed582aec6a5a5d7fa37 Mon Sep 17 00:00:00 2001
+From: Boyuan Yang <byang@debian.org>
+Date: Thu, 31 Dec 2020 12:56:26 -0500
+Subject: [PATCH] configure.ac: Fix quote issue (autoconf 2.70 compat)
+
+One of the AS_IF() macro was not properly quoted. This commit
+fixes that issue.
+
+This patch closes: #132 (fixes this bug report).
+---
+ configure.ac | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index df0220a8..db4bc902 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -656,7 +656,7 @@ AS_IF([test "x$with_qt" != "xno"],
+ 					    [with_qt="no"])])])
+ 
+ AS_IF([test "x$with_qt" != "xno"],
+-   AS_IF([test "x$with_qt5" != "xno"],
++   [AS_IF([test "x$with_qt5" != "xno"],
+     [AC_CHECK_PROGS(MOC, [moc-qt5 moc])
+      AC_MSG_NOTICE([using moc from $MOC])
+      QT_VERSION=`$PKG_CONFIG Qt5Gui --modversion`
+@@ -672,7 +672,7 @@ dnl -fPIC has no effect on Windows and breaks windres
+      QT_VERSION=`$PKG_CONFIG QtGui --modversion`
+      AC_MSG_NOTICE([using Qt version $QT_VERSION])
+      qt_pkgconfig_file="zbar-qt.pc"
+-     ]))
++     ])])
+ 
+ AM_CONDITIONAL([HAVE_QT], [test "x$with_qt" = "xyes"])
+ 


### PR DESCRIPTION
Updated GNOME runtime to 41, updated zbar to 0.23.1 (and used patch for autoconf 2.70 compatibility), deleted `branch` in libadwaita module, used tag in gstreamer modules.