### PR TITLE
Bump GNOME runtime to 43 and llvm to 14

### DIFF
--- a/com.belmoussaoui.Authenticator.json
+++ b/com.belmoussaoui.Authenticator.json
@@ -1,11 +1,11 @@
 {
     "app-id": "com.belmoussaoui.Authenticator",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "42",
+    "runtime-version": "43",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable",
-        "org.freedesktop.Sdk.Extension.llvm12"
+        "org.freedesktop.Sdk.Extension.llvm14"
     ],
     "command": "authenticator",
     "finish-args": [
@@ -21,8 +21,8 @@
     ],
     "build-options": {
         "append-path": "/usr/lib/sdk/rust-stable/bin",
-        "prepend-path": "/usr/lib/sdk/llvm12/bin",
-        "prepend-ld-library-path": "/usr/lib/sdk/llvm12/lib"
+        "prepend-path": "/usr/lib/sdk/llvm14/bin",
+        "prepend-ld-library-path": "/usr/lib/sdk/llvm14/lib"
     },
     "modules": [
         {
@@ -71,53 +71,6 @@
                     "type": "git",
                     "url": "https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad.git",
                     "tag": "1.18.6"
-                }
-            ]
-        },
-        {
-            "name" : "libsass",
-            "buildsystem" : "meson",
-            "builddir" : true,
-            "config-opts" : [
-                "--libdir=/app/lib"
-            ],
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://github.com/lazka/libsass.git",
-                    "commit" : "302397c0c8ae2d7ab02f45ea461c2c3d768f248e"
-                }
-            ]
-        },
-        {
-            "name" : "sassc",
-            "buildsystem" : "meson",
-            "builddir" : true,
-            "config-opts" : [
-                "--libdir=/app/lib"
-            ],
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://github.com/lazka/sassc.git",
-                    "commit" : "82803377c33247265d779af034eceb5949e78354"
-                }
-            ]
-        },
-        {
-            "name": "gtk",
-            "buildsystem": "meson",
-            "config-opts": [
-                "-Dbuild-examples=false",
-                "-Dbuild-tests=false",
-                "-Ddemos=false",
-                "-Dintrospection=disabled"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/gtk.git",
-                    "commit": "b3f04413b486bd3eb7fbb13658b60aa4c517cd1c"
                 }
             ]
         },

--- a/com.belmoussaoui.Authenticator.json
+++ b/com.belmoussaoui.Authenticator.json
@@ -43,7 +43,7 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "git://git.linuxtv.org/zbar.git",
+                    "url": "https://git.linuxtv.org/zbar.git",
                     "commit": "468f6bda627d683b3f40dbaf242c158409666f7e"
                 },
                 {

--- a/com.belmoussaoui.Authenticator.json
+++ b/com.belmoussaoui.Authenticator.json
@@ -16,8 +16,7 @@
         "--socket=wayland",
         "--talk-name=org.freedesktop.secrets",
         "--env=RUST_LOG=authenticator=debug,ashpd=debug",
-        "--env=G_MESSAGES_DEBUG=none",
-        "--own-name=com.belmoussaoui.Authenticator.SearchProvider"
+        "--env=G_MESSAGES_DEBUG=none"
     ],
     "build-options": {
         "append-path": "/usr/lib/sdk/rust-stable/bin",


### PR DESCRIPTION
This removes the gtk build (and deps) since 43 has already a newer version of gtk.